### PR TITLE
Added molecule_to_query

### DIFF
--- a/cmake/modules/FindMySQL.cmake
+++ b/cmake/modules/FindMySQL.cmake
@@ -3,7 +3,7 @@
 ##############################################################################
 #
 # Usage of this module as follows:
-# 
+#
 #   find_package( MySQL )
 #   if(MySQL_FOUND)
 #     include_directories(${MySQL_INCLUDE_DIRS})
@@ -12,7 +12,7 @@
 #
 #
 ##############################################################################
-# 
+#
 # Variables used by this module, they can change the default behaviour and
 # need to set before calling find_package:
 #
@@ -28,7 +28,7 @@
 #                                was found as well as the library.
 #  MySQL_INCLUDE_DIR             MySQL include directory.
 #  MySQL_LIBRARIES               Link to this to use the MySQL library.
-#  MySQL_MAJOR_VERSION           Major version number of MySQL.                   
+#  MySQL_MAJOR_VERSION           Major version number of MySQL.
 #  MySQL_MINOR_VERSION           Minor version number of MySQL.
 #  MySQL_PLUGIN_DIR              Plugin directory.
 #  MySQL_VERSION                 The version numer of MySQL.
@@ -55,7 +55,7 @@ if(UNIX)
                  /usr/bin/
     )
 
-    if(MYSQL_CONFIG) 
+    if(MYSQL_CONFIG)
         message(STATUS "Using mysql-config: ${MYSQL_CONFIG}")
 
         # set INCLUDE_DIR
@@ -107,12 +107,12 @@ ENDIF(UNIX)
 
 find_path(MySQL_INCLUDE_DIR mysql.h
           /usr/local/include
-          /usr/local/include/mysql 
+          /usr/local/include/mysql
           /usr/local/mysql/include
           /usr/local/mysql/include/mysql
           /opt/mysql/mysql/include
           /opt/mysql/mysql/include/mysql
-          /usr/include 
+          /usr/include
           /usr/include/mysql
           ${MYSQL_INCLUDEDIR}
 )
@@ -159,14 +159,20 @@ set(MYSQL_DIRECTORIES
 message(STATUS "MySQL Version: ${MySQL_VERSION}")
 
 set ( ${MySQL_PLUGIN_DIR} "")
-if (${MySQL_VERSION} MATCHES "^5\\.[15]|^6\\.")
-  foreach (MYSQL_DIR ${MYSQL_DIRECTORIES})
-    if (IS_DIRECTORY "${MYSQL_DIR}/plugin")
-      set (MySQL_PLUGIN_DIR "${MYSQL_DIR}/plugin")
-    endif (IS_DIRECTORY "${MYSQL_DIR}/plugin")
-  endforeach (MYSQL_DIR MYSQL_DIRECTORIES)
-endif (${MySQL_VERSION} MATCHES "^5\\.[15]|^6\\.")
-
+exec_program(${MYSQL_CONFIG}
+     ARGS --plugindir
+     OUTPUT_VARIABLE MY_PLUGIN_TEMP)
+if (MY_PLUGIN_TEMP)
+    set ( MySQL_PLUGIN_DIR ${MY_PLUGIN_TEMP})
+else (MY_PLUGIN_TEMP)
+    if (${MySQL_VERSION} MATCHES "^5\\.[15]|^6\\.")
+      foreach (MYSQL_DIR ${MYSQL_DIRECTORIES})
+        if (IS_DIRECTORY "${MYSQL_DIR}/plugin")
+          set (MySQL_PLUGIN_DIR "${MYSQL_DIR}/plugin")
+        endif (IS_DIRECTORY "${MYSQL_DIR}/plugin")
+      endforeach (MYSQL_DIR MYSQL_DIRECTORIES)
+    endif (${MySQL_VERSION} MATCHES "^5\\.[15]|^6\\.")
+endif (MY_PLUGIN_TEMP)
 message(STATUS "MySQL Plugin Dir: ${MySQL_PLUGIN_DIR}")
 if(MySQL_INCLUDE_DIR AND MySQL_LIBRARIES)
     set(MySQL_FOUND TRUE CACHE INTERNAL "MySQL found")

--- a/src/conversion.h
+++ b/src/conversion.h
@@ -216,6 +216,33 @@ void molecule_to_smiles_deinit(UDF_INIT *initid);
 char *molecule_to_smiles(UDF_INIT *initid, UDF_ARGS *args, char *result, unsigned long *length, char *is_null, char *error);
 
 /**
+ * @short Initializes the molecule_to_query function.
+ * @param initid A structure that the init function should fill
+ * @param args A structure which contains arguments and related variables
+ * @param message The error message that should be passed to the user on fail
+ * @return True if an error is raised during the initialization
+ */
+my_bool molecule_to_query_init(UDF_INIT *initid, UDF_ARGS *args, char *message);
+
+/**
+ * @short Should free all resources allocated by molecule_to_query_init().
+ * @param initid The structure filled by molecule_to_query_init()
+ */
+void molecule_to_query_deinit(UDF_INIT *initid);
+
+/**
+ * @short Converts a molecule in MOLECULE_TYPE format to a query molecule in SMARTS.
+ * @param initid A structure filled by molecule_to_query_init()
+ * @param args A structure which contains arguments and related variables
+ * @param result A buffer to save result
+ * @param length A pointer to length of the above buffer
+ * @param is_null Set to 1 if the result is null
+ * @param error Set to 1 if something goes fatally wrong
+ * @return The converted molecule
+ */
+char *molecule_to_query(UDF_INIT *initid, UDF_ARGS *args, char *result, unsigned long *length, char *is_null, char *error);
+
+/**
  * @short Initializes the molecule_to_molecule function.
  * @param initid A structure that the init function should fill
  * @param args A structure which contains arguments and related variables
@@ -595,4 +622,3 @@ char *molecule_to_mol2(UDF_INIT *initid, UDF_ARGS *args, char *result, unsigned 
 #endif /* HAVE_DLOPEN */
 
 #endif /* __CONVERSION_H */
-

--- a/src/conversion_wrapper.cpp
+++ b/src/conversion_wrapper.cpp
@@ -43,7 +43,7 @@
 #include <sstream>
 
 using namespace std;
-using namespace OpenBabel; 
+using namespace OpenBabel;
 
 #if defined(__CYGWIN__) || defined(__MINGW32__)
   // macro to implement static OBPlugin::PluginMapType& Map()
@@ -93,6 +93,50 @@ char *conversion(const char *molecule, const char *inType, const char *outType)
   return retVal;
 }
 
+char *conversionSMA(const char *molecule, const char *inType)
+{
+  string instring(molecule);
+  string outstring;
+  istringstream inStream(instring);
+  ostringstream outStream;
+
+  char *retVal = NULL;
+
+  LibHandler ob_lib;
+
+  if (!ob_lib.isLoaded()) {
+    return retVal;
+  }
+
+  OBConversion conv(&inStream,&outStream);
+
+  if (conv.SetInAndOutFormats(inType, "SMI")) {
+    // Set options
+    /* No molecule name */
+    conv.AddOption("n", OBConversion::OUTOPTIONS);
+    /* Add option which avoids implicit H being added to the SMARTS.
+       The parameter must be present but can be anything.
+       Taken from opisomorph.cpp  */
+    conv.AddOption("h",OBConversion::OUTOPTIONS, "X");
+
+    try {
+      conv.Convert();
+
+      outstring = outStream.str();
+
+      if (outstring[outstring.length()-1] == '\n') {
+        outstring = outstring.substr(0, outstring.length()-1);
+      }
+
+      retVal = strdup(outstring.c_str());
+    }
+    catch(...) {
+    }
+  }
+
+  return retVal;
+}
+
 char *conversionV3000(const char *V3000)
 {
   string instring(V3000);
@@ -112,7 +156,7 @@ char *conversionV3000(const char *V3000)
 
   if (conv.SetInAndOutFormats(MOLECULE_TYPE, "MOL")) {
     // Set options
-    conv.AddOption("3", OBConversion::OUTOPTIONS); 
+    conv.AddOption("3", OBConversion::OUTOPTIONS);
 
     conv.Convert();
 
@@ -155,10 +199,10 @@ char *V3000conversion(const char *molecule)
 
   if (conv.SetInAndOutFormats("MOL", MOLECULE_TYPE)) {
     // Set options
-    conv.AddOption("3", OBConversion::INOPTIONS); 
+    conv.AddOption("3", OBConversion::INOPTIONS);
 
     conv.Convert();
-  
+
     outstring = outStream.str();
 
     if (outstring[outstring.length()-1] == '\n') {
@@ -337,4 +381,3 @@ char *serializeMolecule(const char *molecule) {
 
   return serializeOBMol(mol);
 }
-

--- a/src/conversion_wrapper.h
+++ b/src/conversion_wrapper.h
@@ -48,6 +48,14 @@ extern "C"
   char *conversion(const char *molecule, const char *in_type, const char *out_type);
 
   /**
+   * @short Converts a file format to a smartslike SMILES.
+   * @param molecule The molecule to convert.
+   * @param in_type Input format.
+   * @return converted molecule
+  */
+  char *conversionSMA(const char *molecule, const char *inType);
+
+  /**
    * @short Converts a V3000 molecule to the default molecule type.
    * @param V3000 The V3000 molecule to convert.
    * @return converted molecule.
@@ -102,4 +110,3 @@ extern "C"
 #endif /* __cplusplus */
 
 #endif /* __CONVERSION_WRAPPER_H */
- 

--- a/src/mychemdb.sql
+++ b/src/mychemdb.sql
@@ -24,6 +24,9 @@ CREATE FUNCTION smiles_to_molecule RETURNS STRING SONAME "libmychem.so";
 DROP FUNCTION IF EXISTS molecule_to_smiles;
 CREATE FUNCTION molecule_to_smiles RETURNS STRING SONAME "libmychem.so";
 
+DROP FUNCTION IF EXISTS molecule_to_query;
+CREATE FUNCTION molecule_to_query RETURNS STRING SONAME "libmychem.so";
+
 DROP FUNCTION IF EXISTS molecule_to_molecule;
 CREATE FUNCTION molecule_to_molecule RETURNS STRING SONAME "libmychem.so";
 
@@ -167,4 +170,3 @@ CREATE FUNCTION is_chiral RETURNS INTEGER SONAME "libmychem.so";
 
 DROP FUNCTION IF EXISTS number_of_rings;
 CREATE FUNCTION number_of_rings RETURNS INTEGER SONAME "libmychem.so";
-

--- a/src/mychemdb_macosx.sql
+++ b/src/mychemdb_macosx.sql
@@ -24,6 +24,9 @@ CREATE FUNCTION smiles_to_molecule RETURNS STRING SONAME "libmychem.dylib";
 DROP FUNCTION IF EXISTS molecule_to_smiles;
 CREATE FUNCTION molecule_to_smiles RETURNS STRING SONAME "libmychem.dylib";
 
+DROP FUNCTION IF EXISTS molecule_to_query;
+CREATE FUNCTION molecule_to_query RETURNS STRING SONAME "libmychem.dylib";
+
 DROP FUNCTION IF EXISTS molecule_to_molecule;
 CREATE FUNCTION molecule_to_molecule RETURNS STRING SONAME "libmychem.dylib";
 
@@ -167,4 +170,3 @@ CREATE FUNCTION is_chiral RETURNS INTEGER SONAME "libmychem.dylib";
 
 DROP FUNCTION IF EXISTS number_of_rings;
 CREATE FUNCTION number_of_rings RETURNS INTEGER SONAME "libmychem.dylib";
-

--- a/src/mychemdb_win32.sql
+++ b/src/mychemdb_win32.sql
@@ -24,6 +24,9 @@ CREATE FUNCTION smiles_to_molecule RETURNS STRING SONAME "mychem.dll";
 DROP FUNCTION IF EXISTS molecule_to_smiles;
 CREATE FUNCTION molecule_to_smiles RETURNS STRING SONAME "mychem.dll";
 
+DROP FUNCTION IF EXISTS molecule_to_query;
+CREATE FUNCTION molecule_to_query RETURNS STRING SONAME "mychem.dll";
+
 DROP FUNCTION IF EXISTS molecule_to_molecule;
 CREATE FUNCTION molecule_to_molecule RETURNS STRING SONAME "mychem.dll";
 
@@ -167,4 +170,3 @@ CREATE FUNCTION is_chiral RETURNS INTEGER SONAME "mychem.dll";
 
 DROP FUNCTION IF EXISTS number_of_rings;
 CREATE FUNCTION number_of_rings RETURNS INTEGER SONAME "mychem.dll";
-


### PR DESCRIPTION
Added molecule_to_query, a function to create SMARTS that do not add implicit H similar to what's used in opisomorph in openbabel.
Calling molecule_to_smiles with e.g. an indole will add a hydrogen on the nitrogen, no matter if the h was stated explicitly or not in the input. This will pose problems in match_substruct, leading to substituted compounds not found when doing a search with a bare indole in e.g. MOL-file format.
This change adds molecule_to_query that uses a functionality in OB that will turn off this behavior when the out option "h" is added together with a parameter (this is used in opisomorph).

With this change added, calling the SQL statement

``` SQL
SELECT molecule_to_query(smiles_to_molecule("n1ccc2c1cccc2")), molecule_to_smiles(smiles_to_molecule("n1ccc2c1cccc2"))
, molecule_to_query(smiles_to_molecule("[nH]1ccc2c1cccc2")), molecule_to_smiles(smiles_to_molecule("[nH]1ccc2c1cccc2"));
```

will return

| molecule_to_query(smiles_to_molecule("n1ccc2c1cccc2")) | molecule_to_smiles(smiles_to_molecule("n1ccc2c1cccc2")) | molecule_to_query(smiles_to_molecule("[nH]1ccc2c1cccc2")) | molecule_to_smiles(smiles_to_molecule("[nH]1ccc2c1cccc2")) |
| --- | --- | --- | --- |
| n1ccc2c1cccc2 | [nH]1ccc2c1cccc2 | [nH]1ccc2c1cccc2 | [nH]1ccc2c1cccc2 |
