### PR TITLE
Executable name babel -> obabel

### DIFF
--- a/cmake/modules/FindOpenBabel2.cmake
+++ b/cmake/modules/FindOpenBabel2.cmake
@@ -80,7 +80,7 @@ IF( OPENBABEL2_EXECUTABLE )
 
 ELSE( OPENBABEL2_EXECUTABLE )
   FIND_PROGRAM(OPENBABEL2_EXECUTABLE
-               NAMES babel
+               NAMES obabel
                PATHS
                [HKEY_CURRENT_USER\\SOFTWARE\\OpenBabel\ 2.0.2]
                $ENV{OPENBABEL2_EXECUTABLE}


### PR DESCRIPTION
Open Babel executable `babel` [has been deprecated](http://openbabel.org/docs/current/Command-line_tools/babel.html#babel-vs-obabel) for quite some time, and completely removed in Open Babel v3. Executable `obabel` is provided as alternative since probably v2.3.1, and in v3 replaced `babel`. Thus I suggest using this forward-compatible `obabel` executable instead, as it will most likely work in v2.3.0 or later.