### PR TITLE
CMake support for newer MariaDB

### DIFF
--- a/cmake/modules/FindMySQL.cmake
+++ b/cmake/modules/FindMySQL.cmake
@@ -45,10 +45,16 @@
 ##############################################################################
 
 
+if(DBD_NAME)
+    # Set outside
+else(DBD_NAME)
+    set(DBD_NAME, "mysql")
+endif(DBD_NAME)
+
 if(UNIX)
     set(MYSQL_CONFIG_PREFER_PATH "$ENV{MYSQL_HOME}/bin" CACHE FILEPATH
-        "preferred path to MySQL (mysql_config)")
-    find_program(MYSQL_CONFIG mysql_config
+        "preferred path to MySQL (${DBD_NAME}_config)")
+    find_program(MYSQL_CONFIG ${DBD_NAME}_config
                  ${MYSQL_CONFIG_PREFER_PATH}
                  /usr/local/mysql/bin/
                  /usr/local/bin/
@@ -56,7 +62,7 @@ if(UNIX)
     )
 
     if(MYSQL_CONFIG)
-        message(STATUS "Using mysql-config: ${MYSQL_CONFIG}")
+        message(STATUS "Using ${DBD_NAME}_config: ${MYSQL_CONFIG}")
 
         # set INCLUDE_DIR
         exec_program(${MYSQL_CONFIG}
@@ -113,7 +119,7 @@ find_path(MySQL_INCLUDE_DIR mysql.h
           /opt/mysql/mysql/include
           /opt/mysql/mysql/include/mysql
           /usr/include
-          /usr/include/mysql
+          /usr/include/${DBD_NAME}
           ${MYSQL_INCLUDEDIR}
 )
 


### PR DESCRIPTION
At some point in time MariaDB has ceased to provide convenience aliases for MySQL (I am using MariaDB v10.5.8 on Debian unstable). However, changes in names/paths are trivial, and I suggest introducing new CMake parameter, `DBD_NAME`, to allow user to specify it during the build (`mysql` would remain the default for backwards compatibility). With this PR the following command works with MariaDB:
```
cmake .. -DDBD_NAME=mariadb
```

I am quite inexperienced in writing CMake, so there might be better ways to achieve the main result, but I believe that command line parameter would still be needed to switch between MySQL and MariaDB.

By the way, compiler complains about the inclusion of `m_ctype.h` and `m_string.h` in header files under `src/`. After removing these includes compiler seems happier.