### PR TITLE
Enable arm64 builds

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -22,7 +22,7 @@ jobs:
       # To add more build types (Release, Debug, RelWithDebInfo, etc.)
       # customize the build_type list.
       matrix:
-        os: [ubuntu-22.04,ubuntu-24.04,ubuntu-22.04-arm64,ubuntu-24.04-arm64]
+        os: [ubuntu-22.04,ubuntu-24.04,ubuntu-24.04-arm,ubuntu-22.04-arm]
         build_type: [Release]
         c_compiler: [gcc]
         cpp_compiler: [g++]

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -28,7 +28,7 @@ jobs:
         cpp_compiler: [g++]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Install compiler
       run: |

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -22,7 +22,7 @@ jobs:
       # To add more build types (Release, Debug, RelWithDebInfo, etc.)
       # customize the build_type list.
       matrix:
-        os: [ubuntu-22.04,ubuntu-24.04]
+        os: [ubuntu-22.04,ubuntu-24.04,ubuntu-22.04-arm64,ubuntu-24.04-arm64]
         build_type: [Release]
         c_compiler: [gcc]
         cpp_compiler: [g++]


### PR DESCRIPTION
Adds arm64 builds.

In other work, I have seen a possible arm64 bug. Enabling arm64 builds in this branch will allow us to verify the bug and  the fix.