### PR TITLE
Fix hang on aarch64 when converting to/from InChI format 

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -22,7 +22,7 @@ jobs:
       # To add more build types (Release, Debug, RelWithDebInfo, etc.)
       # customize the build_type list.
       matrix:
-        os: [ubuntu-22.04,ubuntu-24.04]
+        os: [ubuntu-22.04,ubuntu-24.04,ubuntu-22.04-arm64,ubuntu-24.04-arm64]
         build_type: [Release]
         c_compiler: [gcc]
         cpp_compiler: [g++]


### PR DESCRIPTION
Summary

  - Fix denial-of-service vulnerability on aarch64 when converting to/from InChI format
  - On aarch64, char is unsigned by default, which breaks EOF detection in OpenBabel's GetInChI() — comparing an unsigned char to EOF (-1) never succeeds, causing conv.Convert() to loop indefinitely
  - Since Mychem runs as a MySQL UDF plugin, the infinite loop runs inside the MySQL server process. As the loop iterates, it accumulates memory with each failed read attempt, eventually exhausting       
  available memory and crashing the MySQL server. A single InChI conversion query is sufficient to bring down the entire database
  - Replace conv.Convert() with explicit conv.Read(&mol) / conv.Write(&mol) to avoid OpenBabel's internal read loop, and append a trailing newline to the input string as an additional safeguard

Impact
  - This is a denial-of-service bug on aarch64

  Test plan

  - Build and run on aarch64 (e.g. Apple Silicon or ARM Linux)
  - Verify InChI conversion functions (molfile_to_inchi, inchi_to_molfile, etc.) return correct results without hanging
  - Verify non-InChI conversions (SMILES, CAN, CML, MOL) are unaffected

  🤖 Generated with https://claude.com/claude-code